### PR TITLE
Fix generated mock when a parameter is escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 #### Removed
 
 #### Fixed
-- Fix generated mock when a parameter is escaping
+- Fix generated mock when a parameter is escaping [#51](https://github.com/leoture/MockSwift/pull/51)
 
 #### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 #### Removed
 
 #### Fixed
+- Fix generated mock when a parameter is escaping
 
 #### Security
 

--- a/MockSwiftExample/MockSwiftExample.xcodeproj/project.pbxproj
+++ b/MockSwiftExample/MockSwiftExample.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		9E0F3438235A53C0004231C0 /* Generics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0F3437235A53C0004231C0 /* Generics.swift */; };
 		9E0F343A235A53D5004231C0 /* GenericsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E0F3439235A53D5004231C0 /* GenericsTests.swift */; };
+		9E5A50F12364B321003D01BE /* Escaping.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5A50F02364B321003D01BE /* Escaping.swift */; };
+		9E5A50F32364B32E003D01BE /* EscapingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E5A50F22364B32E003D01BE /* EscapingTests.swift */; };
 		9E7C0AFE232012210061BD9B /* GeneratedMocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7C0AFD232012210061BD9B /* GeneratedMocks.swift */; };
 		9E7C0B00232013420061BD9B /* Basics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E7C0AFF232013420061BD9B /* Basics.swift */; };
 		9E7C0B09232033510061BD9B /* MockSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9E7C0B08232033510061BD9B /* MockSwift.framework */; };
@@ -30,6 +32,8 @@
 /* Begin PBXFileReference section */
 		9E0F3437235A53C0004231C0 /* Generics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Generics.swift; sourceTree = "<group>"; };
 		9E0F3439235A53D5004231C0 /* GenericsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericsTests.swift; sourceTree = "<group>"; };
+		9E5A50F02364B321003D01BE /* Escaping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Escaping.swift; sourceTree = "<group>"; };
+		9E5A50F22364B32E003D01BE /* EscapingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EscapingTests.swift; sourceTree = "<group>"; };
 		9E7C0AFD232012210061BD9B /* GeneratedMocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedMocks.swift; sourceTree = "<group>"; };
 		9E7C0AFF232013420061BD9B /* Basics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Basics.swift; sourceTree = "<group>"; };
 		9E7C0B08232033510061BD9B /* MockSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = MockSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -103,6 +107,7 @@
 				9ED78EED232006E900886FEA /* Info.plist */,
 				9E7C0AFF232013420061BD9B /* Basics.swift */,
 				9E0F3437235A53C0004231C0 /* Generics.swift */,
+				9E5A50F02364B321003D01BE /* Escaping.swift */,
 			);
 			path = MockSwiftExample;
 			sourceTree = "<group>";
@@ -114,6 +119,7 @@
 				9ED78EF7232006E900886FEA /* BasicsTests.swift */,
 				9ED78EF9232006E900886FEA /* Info.plist */,
 				9E0F3439235A53D5004231C0 /* GenericsTests.swift */,
+				9E5A50F22364B32E003D01BE /* EscapingTests.swift */,
 			);
 			path = MockSwiftExampleTests;
 			sourceTree = "<group>";
@@ -251,6 +257,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				9E7C0B00232013420061BD9B /* Basics.swift in Sources */,
+				9E5A50F12364B321003D01BE /* Escaping.swift in Sources */,
 				9E0F3438235A53C0004231C0 /* Generics.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -262,6 +269,7 @@
 				9E0F343A235A53D5004231C0 /* GenericsTests.swift in Sources */,
 				9ED78EF8232006E900886FEA /* BasicsTests.swift in Sources */,
 				9E7C0AFE232012210061BD9B /* GeneratedMocks.swift in Sources */,
+				9E5A50F32364B32E003D01BE /* EscapingTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/MockSwiftExample/MockSwiftExample/Escaping.swift
+++ b/MockSwiftExample/MockSwiftExample/Escaping.swift
@@ -1,0 +1,31 @@
+//Escaping.swift
+/*
+ MIT License
+ 
+ Copyright (c) 2019 Jordhan Leoture
+ 
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+ 
+ The above copyright notice and this permission notice shall be included in all
+ copies or substantial portions of the Software.
+ 
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ SOFTWARE.
+ */
+
+import Foundation
+
+// sourcery: AutoMockable
+protocol Escaping {
+  func call(_ block: @escaping (String) -> Bool) -> Bool
+}

--- a/MockSwiftExample/MockSwiftExampleTests/EscapingTests.swift
+++ b/MockSwiftExample/MockSwiftExampleTests/EscapingTests.swift
@@ -1,0 +1,63 @@
+//EscapingTests.swift
+/*
+MIT License
+
+Copyright (c) 2019 Jordhan Leoture
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+import Foundation
+import XCTest
+import MockSwift
+@testable import MockSwiftExample
+
+class EscapingTests: XCTestCase {
+  @Mock private var escaping: Escaping
+
+  func test_call_withTypes() {
+    // block cannot be used as predicate.
+    // Given
+    let block: (String) -> Bool = { $0.isEmpty }
+    given(escaping).call(block).will {
+      ($0[0] as! (String) -> Bool)("")
+    }
+
+    // When
+    let result = escaping.call(block)
+
+    //Then
+    XCTAssertFalse(result)
+    then(escaping).call(block).called(times: 0)
+  }
+
+  func test_call_withPredicates() {
+    // Given
+    given(escaping).call(.any()).will {
+      ($0[0] as! (String) -> Bool)("")
+    }
+
+    // When
+    let result = escaping.call { $0.isEmpty }
+
+    //Then
+    XCTAssertTrue(result)
+    then(escaping).call(.any()).called()
+  }
+}

--- a/MockSwiftExample/MockSwiftExampleTests/Generated/GeneratedMocks.swift
+++ b/MockSwiftExample/MockSwiftExampleTests/Generated/GeneratedMocks.swift
@@ -16,6 +16,7 @@ import MockSwift
 
 
 
+
 // MARK: - Basics
 extension Mock: Basics where WrappedType == Basics {
   public func doSomething() {
@@ -112,6 +113,33 @@ extension MockThen where WrappedType == Basics {
   }
   public func doSomething(with arg1: String, and arg2: Bool) -> Verifiable<String> {
     verifiable(arg1, arg2)
+  }
+}
+
+// MARK: - Escaping
+extension Mock: Escaping where WrappedType == Escaping {
+  public func call(_ block: @escaping (String) -> Bool) -> Bool {
+    mocked(block)
+  }
+}
+
+
+extension MockGiven where WrappedType == Escaping {
+  public func call(_ block: Predicate<(String) -> Bool>) -> Mockable<Bool> {
+    mockable(block)
+  }
+  public func call(_ block: @escaping (String) -> Bool) -> Mockable<Bool> {
+    mockable(block)
+  }
+}
+
+
+extension MockThen where WrappedType == Escaping {
+  public func call(_ block: Predicate<(String) -> Bool>) -> Verifiable<Bool> {
+    verifiable(block)
+  }
+  public func call(_ block: @escaping (String) -> Bool) -> Verifiable<Bool> {
+    verifiable(block)
   }
 }
 

--- a/Templates/MockSwift.stencil
+++ b/Templates/MockSwift.stencil
@@ -2,9 +2,11 @@ import Foundation
 import MockSwift
 @testable import {{argument.module}}
 
-{% macro predicatesParameter method %}{% for param in method.parameters %}{% if param.argumentLabel == null %}_ {% elif param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: Predicate<{{ param.typeName }}>{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+{% macro predicatesParameter method %}{% for param in method.parameters %}{% if param.argumentLabel == null %}_ {% elif param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: Predicate<{{ param.unwrappedTypeName if param.typeAttributes.escaping else param.typeName }}>{{ ', ' if not forloop.last }}{% endfor %}{% endmacro %}
 
-{% macro parametersOnInvoke method %}{% for param in method.parameters %}{{ param.name }}{% if not forloop.last %}, {% endif %}{% endfor %}{% endmacro %}
+{% macro normalizeParameter method %}{% for param in method.parameters %}{% if param.argumentLabel == null %}_ {% elif param.argumentLabel != param.name %}{{ param.argumentLabel }} {% endif %}{{ param.name }}: {% if param.typeName|contains:"->" %}@escaping {{ param.unwrappedTypeName }}{% else %}{{ param.typeName }}{% endif %}{{ ', ' if not forloop.last }}{% endfor %}{% endmacro %}
+
+{% macro parametersOnInvoke method %}{% for param in method.parameters %}{{ param.name }}{{ ', ' if not forloop.last }}{% endfor %}{% endmacro %}
 
 {% macro mockMethod method %}
   public func {{ method.name }}{{ ' throws' if method.throws }}{% if not method.returnTypeName.isVoid %} -> {{ method.returnTypeName.name }}{% endif %} {
@@ -31,7 +33,7 @@ extension Mock: {{ type.name }} where WrappedType == {{ type.name }} {
     mockable({% call parametersOnInvoke method %})
   }
   {% if method.parameters.count > 0 %}
-  public func {{ method.name }} -> Mockable{% call normalizeReturnType method.returnTypeName %} {
+  public func {{ method.shortName }}({% call normalizeParameter method %}) -> Mockable{% call normalizeReturnType method.returnTypeName %} {
     mockable({% call parametersOnInvoke method %})
   }
   {% endif %}
@@ -52,7 +54,7 @@ extension MockGiven where WrappedType == {{ type.name }} {
     verifiable({% call parametersOnInvoke method %})
   }
   {% if method.parameters.count > 0 %}
-  public func {{ method.name }} -> Verifiable{% call normalizeReturnType method.returnTypeName %} {
+  public func {{ method.shortName }}({% call normalizeParameter method %}) -> Verifiable{% call normalizeReturnType method.returnTypeName %} {
     verifiable({% call parametersOnInvoke method %})
   }
   {% endif %}


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING](https://github.com/leoture/MockSwift/blob/master/CONTRIBUTING.md).  

###### 🔗 Closing issues  
This closes #44 

# 📖 Summary
see #44 

###### ℹ️ Other information
Each block must be annotated with `@escaping` in the protocol, otherwise we cannot pass it on `mocked(...)`.