### PR TITLE
Feature/disambiguate predicates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 #### Changed
 - Template sourcery only generates Mock with AutoMockable annotation [#43](https://github.com/leoture/MockSwift/pull/43)
+- The Input type of Predicate.match and Predicate.any can be disambiguate
 
 #### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 
 #### Changed
 - Template sourcery only generates Mock with AutoMockable annotation [#43](https://github.com/leoture/MockSwift/pull/43)
-- The Input type of Predicate.match and Predicate.any can be disambiguate
+- The Input type of Predicate.match and Predicate.any can be disambiguate [#58](https://github.com/leoture/MockSwift/pull/58)
 
 #### Deprecated
 

--- a/MockSwiftExample/MockSwiftExampleTests/BasicsTests.swift
+++ b/MockSwiftExample/MockSwiftExampleTests/BasicsTests.swift
@@ -39,7 +39,7 @@ class BasicsTests: XCTestCase {
       $0.doSomething().willReturn(0)
       $0.doSomething().willReturn(nil)
       $0.doSomething(arg: =="2").willReturn("2")
-      $0.doSomething(arg: .match(\.isEmpty)).willThrow(error)
+      $0.doSomething(arg: .match(when: \.isEmpty)).willThrow(error)
       $0.doSomething(arg1: =="3", arg2: .isNil()).willReturn("3")
       $0.doSomething(with: =="4").willReturn("4")
       $0.doSomething(with: =="5", and: .isTrue()).willReturn("5")

--- a/MockSwiftExample/MockSwiftExampleTests/GenericsTests.swift
+++ b/MockSwiftExample/MockSwiftExampleTests/GenericsTests.swift
@@ -37,8 +37,8 @@ class GenericsTests: XCTestCase {
     given(generics) {
       $0.doSomething().willReturn(0)
       $0.doSomething().willReturn("1")
-      $0.doSomething(with: Predicate<[Int]>.match(\.isEmpty)).will { _ in blockDone = true }
-      $0.doSomething(arg: Predicate<Bool>.isTrue()).willThrow(error)
+      $0.doSomething(with: .match(any: [Int].self, when: \.isEmpty)).will { _ in blockDone = true }
+      $0.doSomething(arg: .isTrue()).willThrow(error)
       $0.doSomething(arg1: ==[2], arg2: .isNil()).willReturn(2)
       $0.doSomething(with: ==3, and: =="3").willReturn(true)
     }
@@ -66,8 +66,8 @@ class GenericsTests: XCTestCase {
     then(generics) {
       $0.doSomething().disambiguate(with: Int.self).called(times: 1)
       $0.doSomething().disambiguate(with: String.self).called(times: 1)
-      $0.doSomething(with: Predicate<[Int]>.match(\.isEmpty)).called(times: 1)
-      $0.doSomething(arg: Predicate<Bool>.isTrue()).called(times: 1)
+      $0.doSomething(with: .match(any: [Int].self, when: \.isEmpty)).called(times: 1)
+      $0.doSomething(arg: .isTrue()).called(times: 1)
       $0.doSomething(arg1: ==[2], arg2: .isNil()).called(times: 1)
       $0.doSomething(with: ==3, and: =="3").called(times: 1)
     }

--- a/Sources/MockSwift/Predicates/Predicate.swift
+++ b/Sources/MockSwift/Predicates/Predicate.swift
@@ -46,44 +46,31 @@ public class Predicate<Input> {
 
   /// Creates a `Predicate<Input>`.
   /// - Parameter description: The description of the Predicate.
+  /// - Parameter type: The type to match.
   /// - Parameter predicate: The block that will be used to verify that the entry statisfies the Predicate.
   /// - Returns: A new `Predicate<Input>`.
-  public static func match(description: String = "custom matcher",
+  public static func match(description: String? = nil,
+                           any type: Input.Type = Input.self,
                            _ predicate: @escaping (Input) -> Bool) -> Predicate<Input> {
-    Predicate(description: description, predicate: predicate)
-  }
-
-  /// Creates a `AnyPredicate`.
-  /// - Parameter value: The value to match.
-  /// - Parameter file: The file name where the method is called.
-  /// - Parameter line: The line where the method is called.
-  /// - Returns: A `AnyPredicate` able to match `value`.
-  /// - Important: If value cannot be cast to `AnyPredicate` or to `AnyObject` a `fatalError` will be raised.
-  public static func match(_ value: Input,
-                           file: StaticString = #file,
-                           line: UInt = #line) -> AnyPredicate {
-    switch value {
-    case let value as AnyPredicate: return value
-    case let value as AnyObject: return Predicate<AnyObject>.match(description: "\(value)") { $0 === value }
-    default: return ErrorHandler().handle(
-      InternalError.castTwice(source: value, firstTarget: AnyPredicate.self, secondTarget: AnyObject.self),
-      file: file,
-      line: line)
-    }
+    Predicate(description: description ?? "a \(type)", predicate: predicate)
   }
 
   /// Creates a `Predicate<Input>`.
   /// - Parameter description: The description of the Predicate.
+  /// - Parameter type: The type to match.
   /// - Parameter keyPath: The keyPath that will be used to verify that the entry statisfies the Predicate.
   /// - Returns: A new `Predicate<Input>`.
-  public class func match(description: String = "KeyPath matcher",
-                          _ keyPath: KeyPath<Input, Bool>) -> Predicate<Input> {
-    .match(description: description) { $0[keyPath: keyPath] }
+  public class func match(description: String? = nil,
+                          any type: Input.Type = Input.self,
+                          when keyPath: KeyPath<Input, Bool>) -> Predicate<Input> {
+    .match(description: description ?? "a \(type)") { $0[keyPath: keyPath] }
   }
 
   /// Creates a `Predicate<Input>` able to match any value of type `Input`.
-  public static func any() -> Predicate<Input> {
-    .match(description: "any") { _ in true }
+  /// - Parameter type: The type to match.
+  /// - Returns: A new `Predicate<Input>`.
+  public static func any(_ type: Input.Type = Input.self) -> Predicate<Input> {
+    .match(description: "any \(type)") { _ in true }
   }
 
   /// Creates a `Predicate<Input>` able to match any value of type `Input` not matched by an other predicate.
@@ -93,6 +80,26 @@ public class Predicate<Input> {
     .match(description: "not \(predicate)") { !predicate.satisfy(by: $0) }
   }
 
+  // MARK: - Methods
+
+  /// Creates a `AnyPredicate`.
+  /// - Parameter value: The value to match.
+  /// - Parameter file: The file name where the method is called.
+  /// - Parameter line: The line where the method is called.
+  /// - Returns: A `AnyPredicate` able to match `value`.
+  /// - Important: If value cannot be cast to `AnyPredicate` or to `AnyObject` a `fatalError` will be raised.
+  static func match(_ value: Input,
+                    file: StaticString = #file,
+                    line: UInt = #line) -> AnyPredicate {
+    switch value {
+    case let value as AnyPredicate: return value
+    case let value as AnyObject: return Predicate<AnyObject>.match(description: "\(value)") { $0 === value }
+    default: return ErrorHandler().handle(
+      InternalError.castTwice(source: value, firstTarget: AnyPredicate.self, secondTarget: AnyObject.self),
+      file: file,
+      line: line)
+    }
+  }
 }
 
 // MARK: - AnyPredicate

--- a/Tests/MockSwiftTests/Mocks/MockGivenIntegrationTests.swift
+++ b/Tests/MockSwiftTests/Mocks/MockGivenIntegrationTests.swift
@@ -49,7 +49,7 @@ class MockGivenIntegrationTests: XCTestCase {
 
   func test_function_shouldReturnValueFromWillCompletion() {
     // Given
-    given(custom).function(identifier: .not(.match(\.isEmpty)))
+    given(custom).function(identifier: .not(.match(when: \.isEmpty)))
       .disambiguate(with: String.self)
       .will { parameters in (parameters[0] as? String ?? "") + "1" }
 

--- a/Tests/MockSwiftTests/Mocks/MockThenIntegrationTests.swift
+++ b/Tests/MockSwiftTests/Mocks/MockThenIntegrationTests.swift
@@ -80,7 +80,7 @@ class MockThenIntegrationTests: XCTestCase {
     let _: String = custom.function(identifier: "arg2")
 
     //Then
-    let receivedParameters = then(custom).function(identifier: .not(.match(\.isEmpty)))
+    let receivedParameters = then(custom).function(identifier: .not(.match(when: \.isEmpty)))
       .disambiguate(with: String.self)
       .receivedParameters
     XCTAssertEqual(receivedParameters as? [[String]], [["arg1"], ["arg2"]])
@@ -95,7 +95,7 @@ class MockThenIntegrationTests: XCTestCase {
     let _: String = custom.function(identifier: "arg2")
 
     //Then
-    let callCount = then(custom).function(identifier: .not(.match(\.isEmpty)))
+    let callCount = then(custom).function(identifier: .not(.match(when: \.isEmpty)))
       .disambiguate(with: String.self)
       .callCount
     XCTAssertEqual(callCount, 2)

--- a/Tests/MockSwiftTests/Predicates/PredicateTests.swift
+++ b/Tests/MockSwiftTests/Predicates/PredicateTests.swift
@@ -24,34 +24,46 @@
  */
 
 import XCTest
-import MockSwift
+@testable import MockSwift
 
 private class Custom {}
 
 class PredicateTests: XCTestCase {
 
+  // MARK: - match(description:any type:_ predicate:)
+
   func test_match_withMatchShouldReturnFalseIfInputIsNotTheSameType() {
-    let predicate: Predicate<String> = .match { _ in
-      true
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertFalse(predicate.satisfy(by: 1))
     }
-    XCTAssertFalse(predicate.satisfy(by: 1))
+
+    assertion(.match(any: String.self) { _ in true })
   }
 
   func test_match_shouldReturnFalseIfInputNotMatched() {
-    let predicate: Predicate<String> = .match { value in
-      value.isEmpty
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertFalse(predicate.satisfy(by: "not Empty"))
     }
 
-    XCTAssertFalse(predicate.satisfy(by: "not Empty"))
+    assertion(.match(any: String.self) {$0.isEmpty})
   }
 
   func test_match_shouldReturnTrueIfInputMatched() {
-    let predicate: Predicate<String> = .match { value in
-      value.isEmpty
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertTrue(predicate.satisfy(by: ""))
     }
 
-    XCTAssertTrue(predicate.satisfy(by: ""))
+    assertion(.match(any: String.self) {$0.isEmpty})
   }
+
+  func test_match_description() {
+    let predicate: Predicate<String> = .match { _ in
+      true
+    }
+    XCTAssertEqual("\(predicate)", "a String")
+  }
+
+  // MARK: - match(_ value:file:line:)
 
   func test_match_shouldReturnTrueIfInputMatchedByAnyPredicate() {
     let anyPredicate: AnyPredicate = Predicate<String>.match { value in
@@ -85,45 +97,52 @@ class PredicateTests: XCTestCase {
     XCTAssertFalse(predicate.satisfy(by: Custom()))
   }
 
-  func test_match_description() {
-    let predicate: Predicate<String> = .match(description: "description") { _ in
-      true
-    }
-    XCTAssertEqual("\(predicate)", "description")
-  }
+  // MARK: - match(description:any type:when keyPath:)
 
   func test_match_shouldReturnTrueIfKeyPathReturnTrue() {
-    let predicate: AnyPredicate = Predicate<String>.match(\.isEmpty)
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertTrue(predicate.satisfy(by: ""))
+    }
 
-     XCTAssertTrue(predicate.satisfy(by: ""))
-   }
+    assertion(.match(any: String.self, when: \.isEmpty))
+  }
 
-   func test_match_shouldReturnFalseIfKeyPathReturnFalse() {
-     let predicate: AnyPredicate = Predicate<String>.match(\.isEmpty)
+  func test_match_shouldReturnFalseIfKeyPathReturnFalse() {
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertFalse(predicate.satisfy(by: "not Empty"))
+    }
 
-     XCTAssertFalse(predicate.satisfy(by: "not Empty"))
-   }
+    assertion(.match(any: String.self, when: \.isEmpty))
+  }
 
-   func test_match_KeyPathDescription() {
-     let predicate: AnyPredicate = Predicate<String>.match(description: "description", \.isEmpty)
+  func test_match_KeyPathDescription() {
+    let predicate: Predicate<String> = .match(when: \.isEmpty)
 
-     XCTAssertEqual("\(predicate)", "description")
-   }
+    XCTAssertEqual("\(predicate)", "a String")
+  }
+
+  // MARK: - any(_ type:)
 
   func test_any_shouldReturnFalse() {
-    let predicate: Predicate<String> = .any()
-    XCTAssertFalse(predicate.satisfy(by: 1))
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertFalse(predicate.satisfy(by: 1))
+    }
+
+    assertion(.any(String.self))
   }
 
   func test_any_shouldReturnTrue() {
-    let predicate: Predicate<String> = .any()
-    XCTAssertTrue(predicate.satisfy(by: ""))
+    func assertion<T>(_ predicate: Predicate<T>) {
+      XCTAssertTrue(predicate.satisfy(by: ""))
+    }
+
+    assertion(.any(String.self))
   }
 
   func test_any_description() {
     let predicate: Predicate<String> = .any()
 
-    XCTAssertEqual("\(predicate)", "any")
+    XCTAssertEqual("\(predicate)", "any String")
   }
 
   func test_not_shouldReturnFalse() {
@@ -138,7 +157,6 @@ class PredicateTests: XCTestCase {
 
   func test_not_description() {
     let predicate: Predicate<String> = .not(.match(description: "description") { _ in true })
-
     XCTAssertEqual("\(predicate)", "not description")
   }
 }


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING](https://github.com/leoture/MockSwift/blob/master/CONTRIBUTING.md).  

###### 🔗 Closing issues  
This closes #48 , closes #47 

# 📖 Summary
We can now specify the Input type of Predicate.match and Predicate.any when its can not be inferred. `.match(any: String.self) { $0.isEmpty }` `.match(any: String.self, when: \.isEmpty)` `.any(String.self)`
The default description change to "a \(type)"

### 🛠 About Implementation
Just a new parameter with default value to `Input.self`

### ✅ About Testing
To create this ambiguity we need a Predicate with a generic Input type.  
That is why each test has an `assertion` function.

