### PR TITLE
fix 'Float80' compatibility in ARM architecture

### DIFF
--- a/Sources/MockSwift/Registers/Stubs/GlobalStub.swift
+++ b/Sources/MockSwift/Registers/Stubs/GlobalStub.swift
@@ -67,9 +67,11 @@ extension Double: GlobalStub {
 extension Float: GlobalStub {
     public static func stub() -> Self { 0.0 }
 }
+#if !os(Windows) && (arch(i386) || arch(x86_64))
 extension Float80: GlobalStub {
     public static func stub() -> Self { 0.0 }
 }
+#endif
 extension Decimal: GlobalStub {
     public static func stub() -> Self { 0.0 }
 }

--- a/Tests/MockSwiftTests/Functions/Behaviour/GlobalStubExtensionTests.swift
+++ b/Tests/MockSwiftTests/Functions/Behaviour/GlobalStubExtensionTests.swift
@@ -43,7 +43,9 @@ class GlobalStubExtensionTests: XCTestCase {
 
     func test_stub_Double() { XCTAssertEqual(Double.stub(), 0.0) }
     func test_stub_Float() { XCTAssertEqual(Float.stub(), 0.0) }
+    #if !os(Windows) && (arch(i386) || arch(x86_64))
     func test_stub_Float80() { XCTAssertEqual(Float80.stub(), 0.0) }
+    #endif
     func test_stub_Decimal() { XCTAssertEqual(Decimal.stub(), 0.0) }
     func test_stub_NSNumber() { XCTAssertEqual(NSNumber.stub(), 0.0) }
 


### PR DESCRIPTION
- [x] I have read the [CONTRIBUTING](https://github.com/leoture/MockSwift/blob/master/CONTRIBUTING.md).  

###### 🔗 Closing issues  
This closes #119
